### PR TITLE
Fix issue: Test suite fails with Catalyst 5.90082

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,7 @@
 Revision history for perl module Plack::Middleware::Debug::CatalystStash
 
+0.001003 2015-08-03
+    - Fix for Catalyst 5.9.0082 and later
 0.001002 2014-03-05
     - use Catalyst to prevent error when loading before Catalyst has been used
     - added test to check loads ok


### PR DESCRIPTION
With more recent versions of Catalyst, it looks like the before finalize modifier where stash is stored is not getting a reference to the actual req->env of the $c variable. So when 'plack.middleware.catalyst_stash' is set it's not set on what the run function got. This fixes that by storing the reference passed to run, using that for the finalize modifier, then unsetting it when we are done throwing it into the debug panel.
