### PR TITLE
move handler into middleware and save in a lexical

### DIFF
--- a/lib/Plack/Middleware/Debug/CatalystStash.pm
+++ b/lib/Plack/Middleware/Debug/CatalystStash.pm
@@ -12,23 +12,23 @@ use HTML::Entities qw/encode_entities_numeric/;
 
 our $VERSION = '0.001002';
 
-install_modifier 'Catalyst', 'before', 'finalize' => sub {
-    my $c = shift;
-
-    local $Data::Dumper::Terse = 1;
-    local $Data::Dumper::Indent = 1;
-    local $Data::Dumper::Deparse = 1;
-    $c->req->env->{'plack.middleware.catalyst_stash'} =
-        encode_entities_numeric( Dumper( $c->stash ) );
-};
-
 sub run {
     my($self, $env, $panel) = @_;
+
+    my $dump;
+    install_modifier 'Catalyst', 'before', 'finalize' => sub {
+        my $c = shift;
+
+        local $Data::Dumper::Terse = 1;
+        local $Data::Dumper::Indent = 1;
+        local $Data::Dumper::Deparse = 1;
+        $dump = encode_entities_numeric( Dumper( $c->stash ) );
+    };
 
     return sub {
         my $res = shift;
 
-        my $stash = delete $env->{'plack.middleware.catalyst_stash'} || 'No Stash';
+        my $stash = $dump || 'No Stash';
         $panel->content("<pre>$stash</pre>");
     };
 }


### PR DESCRIPTION
There was a change somewhere (probably in Catalyst) at some point that made $env in $c->req->env not be the same as the $env we have in the handler. I believe it gets copied or weakened somewhere, but I could not find it. If $c->req->env or $c->engine->env (which is just for back compatibility and there are comments saying it will go away) are used inside of process in a Catalyst::View:: class, the old approach using $env in the debug pannel works. But we cannot do that here, because it needs to be generic so it works with any View class, and Catalyst::View::process gets overwritten by subclasses, so we cannot add a modifier to it as it's never called.

This solution of adding the handler with a closure over a local variable inside of the actual middleware function is less performant as it gets called every time and not just when the class is loaded. But since we're in a development environment when this gets used that shouldn't be a big problem.

Fixes #1